### PR TITLE
Update .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,2 @@
 * text=auto eol=lf
+io/** linguist-vendored


### PR DESCRIPTION
Stop `linguist` from indexing our `io/` directory, causing incorrect language statistics